### PR TITLE
Pinning scanner versions (remaining once)

### DIFF
--- a/.github/workflows/docker.image.yml
+++ b/.github/workflows/docker.image.yml
@@ -211,7 +211,7 @@ jobs:
           docker image ls -a
           docker push localhost:5000/foobar/${{ env.IMAGE_NAME }}
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.33.1
         with:
           image-ref: localhost:5000/foobar/${{ env.IMAGE_NAME }}
           format: "template"
@@ -246,7 +246,7 @@ jobs:
           docker image ls -a
           docker push localhost:5000/foobar/${{ env.IMAGE_NAME }}
       - name: Run the Anchore scan action itself with GitHub Advanced Security code scanning integration enabled
-        uses: anchore/scan-action@main
+        uses: anchore/scan-action@v7.0.0
         with:
           image: localhost:5000/foobar/${{ env.IMAGE_NAME }}
           acs-report-enable: true


### PR DESCRIPTION
## Summary by Sourcery

Pin Trivy and Anchore scanner actions to fixed versions in the Docker image CI workflow

CI:
- Pin aquasecurity/trivy-action to v0.33.1
- Pin anchore/scan-action to v7.0.0